### PR TITLE
Create output : stack plot 

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -188,24 +188,21 @@ app_ui = ui.page_fluid(
             ui.layout_columns(
                 ui.card(
                     ui.card_header("Sales Mix Over Time"),
-                    ui.layout_columns(
-                        ui.panel_conditional(   # Used Claude.ai to suggest which ui.* to use for adding a slider conditional on user input
-                            "input.input_agg === 'day'", # If the user chooses to aggregate by day, then use a slider to determine what date range to show
-                            ui.input_slider(
-                                "input_slider_range",
-                                "Select a date range:",
-                                min = pd.to_datetime('2019-01-01'),
-                                max = pd.to_datetime('2019-03-31'),
-                                value = [pd.to_datetime('2019-02-01'),pd.to_datetime('2019-02-28')],
-                                ticks = True,
-                                step = 1,
-                                time_format="%Y-%m-%d"
-                            ),
-                              ui.help_text(
-                                  "Suggested range size : 1 month" 
-                                  ),
+                    ui.panel_conditional(   # Used Claude.ai to suggest which ui.* to use for adding a slider conditional on user input
+                        "input.input_agg === 'day'", # If the user chooses to aggregate by day, then use a slider to determine what date range to show
+                        ui.input_slider(
+                            "input_slider_range",
+                            "Select a date range:",
+                            min = pd.to_datetime('2019-01-01'),
+                            max = pd.to_datetime('2019-03-31'),
+                            value = [pd.to_datetime('2019-02-01'),pd.to_datetime('2019-02-28')],
+                            ticks = True,
+                            step = 1,
+                            time_format="%Y-%m-%d"
                         ),
-                        col_widths=[7, 5]
+                            ui.help_text(
+                                "For the best results, use the slider to select a smaller date range to view (we suggest one month)." 
+                                ),
                     ),
                     output_widget("plot_sales_mix"),
                     full_screen=True


### PR DESCRIPTION
- Closes #32 
- TO DO (before merging to dev) : add reactive calc data, decide if we want to keep the comparison types

The plot doesn't depend on all the input metrics yet, for now it just changes based on aggregation method. I'll add the other inputs once they've been added.

When I first made the plot I realised that when it was aggregated by day it was quite squished  so I decided to add an input slider so that we can show just one part of the plot at a time. The range can be decided by the user with the slider.

I also decided to add a comparison option so that the user can decided what comparison to highlight (e.g product line, customer type, gender, payment type). If you guys think this is too much for the dashboard we can remove it. If we keep it we might have to update the user story to include the other comparison types.