### PR TITLE
Update qc dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - shinywidgets=0.7.1
   - matplotlib=3.10.8
   - altair-all=5.5.0
-  - vegafusion=1.6.9
+  - vegafusion=2.0.3 
   - nb_conda_kernels=2.5.1 
   - pip=26.0.1
   - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas==3.0.0
 matplotlib==3.10.8
 altair==5.5.0
 altair_ally==0.1.1
-vegafusion[embed]==1.6.9
+vegafusion[embed]==2.0.3
 querychat==0.5.1 
 chatlas==0.15.2 
 python-dotenv==1.2.2


### PR DESCRIPTION
- Closes #75 
- Adds the following dependencies to `environment.yml` and `requirement.txt` required for the chat interface : querychat, chatlas, python-dotenv
- Changed vegafusion version to 2.0.3 as it was causing dependency issues